### PR TITLE
Feature: Support image subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ The following describes which fields exist when doing requests to the API. We on
     "images": [
       {
         "name": "example_image_name.png",
-        "image": "base64_encoded_string"
+        "image": "base64_encoded_string",
+        "subfolder": "my_subfolder",
       }
     ]
   }
@@ -179,14 +180,15 @@ The following describes which fields exist when doing requests to the API. We on
 
 #### "input.images"
 
-An array of images, where each image should have a different name.
+An array of images, where each image should have a different name. An optional subfolder can be specified for each image to allow for structuring of inputs.
 
 🚨 The request body for a RunPod endpoint is 10 MB for `/run` and 20 MB for `/runsync`, so make sure that your input images are not super huge as this will be blocked by RunPod otherwise, see the [official documentation](https://docs.runpod.io/docs/serverless-endpoint-urls)
 
-| Field Name | Type   | Required | Description                                                                              |
-| ---------- | ------ | -------- | ---------------------------------------------------------------------------------------- |
-| `name`     | String | Yes      | The name of the image. Please use the same name in your workflow to reference the image. |
-| `image`    | String | Yes      | A base64 encoded string of the image.                                                    |
+| Field Name  | Type   | Required | Description                                                                              |
+| ----------- | ------ | -------- | ---------------------------------------------------------------------------------------- |
+| `name`      | String | Yes      | The name of the image. Please use the same name in your workflow to reference the image. |
+| `image`     | String | Yes      | A base64 encoded string of the image.                                                    |
+| `subfolder` | String | No       | Optional subfolder for the image relative to the input directory.                        |
 
 ## Interact with your RunPod API
 

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -130,6 +130,9 @@ def upload_images(images):
             "overwrite": (None, "true"),
         }
 
+        if image.get("subfolder"):
+            files["subfolder"] = (None, image["subfolder"])
+
         # POST request to upload the image
         response = requests.post(f"http://{COMFY_HOST}/upload/image", files=files)
         if response.status_code != 200:


### PR DESCRIPTION
## Motivation

The ComfyUI "Save Image" node automatically creates parent folders if subfolders are provided in the save name. The ComfyUI API correspondingly provides the subfolder for a given output with the `subfolder` key.

Supporting subfolders would allow for better structuring of outputs, e.g. by saving images in a job-specific output folder.

This PR implements providing the subfolder as an additional key for each output image. The changes are non-breaking, as the key can simply be ignored and the behavior of the other keys otherwise stays the same.

## Issues closed

No related issue; implemented it for personal use.

## Todo

- [ ] Implement tests after this initial proposal is approved.
