### PR TITLE
fix: convert environment variables to int

### DIFF
--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -13,9 +13,9 @@ from io import BytesIO
 COMFY_API_AVAILABLE_INTERVAL_MS = 50
 # Maximum number of API check attempts
 COMFY_API_AVAILABLE_MAX_RETRIES = 500
-# Time to wait between poll attempts in milliseconds (converted to int)
+# Time to wait between poll attempts in milliseconds
 COMFY_POLLING_INTERVAL_MS = int(os.environ.get("COMFY_POLLING_INTERVAL_MS", 250))
-# Maximum number of poll attempts (converted to int)
+# Maximum number of poll attempts
 COMFY_POLLING_MAX_RETRIES = int(os.environ.get("COMFY_POLLING_MAX_RETRIES", 500))
 # Host where ComfyUI is running
 COMFY_HOST = "127.0.0.1:8188"

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -13,10 +13,10 @@ from io import BytesIO
 COMFY_API_AVAILABLE_INTERVAL_MS = 50
 # Maximum number of API check attempts
 COMFY_API_AVAILABLE_MAX_RETRIES = 500
-# Time to wait between poll attempts in milliseconds
-COMFY_POLLING_INTERVAL_MS = os.environ.get("COMFY_POLLING_INTERVAL_MS", 250)
-# Maximum number of poll attempts
-COMFY_POLLING_MAX_RETRIES = os.environ.get("COMFY_POLLING_MAX_RETRIES", 500)
+# Time to wait between poll attempts in milliseconds (converted to int)
+COMFY_POLLING_INTERVAL_MS = int(os.environ.get("COMFY_POLLING_INTERVAL_MS", 250))
+# Maximum number of poll attempts (converted to int)
+COMFY_POLLING_MAX_RETRIES = int(os.environ.get("COMFY_POLLING_MAX_RETRIES", 500))
 # Host where ComfyUI is running
 COMFY_HOST = "127.0.0.1:8188"
 # Enforce a clean state after each job is done


### PR DESCRIPTION
COMFY_POLLING_INTERVAL_MS and COMFY_POLLING_MAX_RETRIES should be integers.

## Motivation

fix conversion of environment variables to integers

## Issues closed

fixes https://github.com/blib-la/runpod-worker-comfy/issues/68